### PR TITLE
Indicate if an deviation exist in an income month - An deviation may …

### DIFF
--- a/src/main/kotlin/no/nav/dagpenger/inntekt/klassifisering/Inntektsklassifisering.kt
+++ b/src/main/kotlin/no/nav/dagpenger/inntekt/klassifisering/Inntektsklassifisering.kt
@@ -6,23 +6,24 @@ import no.nav.dagpenger.inntekt.inntektskomponenten.v1.InntektkomponentResponse
 import no.nav.dagpenger.inntekt.inntektskomponenten.v1.SpesielleInntjeningsforhold
 import kotlin.reflect.KFunction
 
-// todo - TEST THIS!!! MISSING UNIT TEST
-
 fun klassifiserInntekter(uklassifiserteInntekter: InntektkomponentResponse): List<KlassifisertInntektMåned> {
 
     return uklassifiserteInntekter.arbeidsInntektMaaned?.map { måned ->
         val årMåned = måned.aarMaaned
         val avvik = måned.avvikListe ?: emptyList()
-        val klassifiserteInntekter = måned.arbeidsInntektInformasjon?.inntektListe?.map { inntekt ->
-            val datagrunnlagKlassifisering = DatagrunnlagKlassifisering(
-                inntekt.inntektType,
-                inntekt.beskrivelse,
-                inntekt.tilleggsinformasjon?.tilleggsinformasjonDetaljer?.spesielleInntjeningsforhold
-            )
+        val klassifiserteInntekter = måned.arbeidsInntektInformasjon
+                ?.inntektListe
+                ?.filterNot { inntekt -> avvik.any { it.ident == inntekt.inntektsmottaker && it.opplysningspliktig == inntekt.opplysningspliktig } }
+                ?.map { inntekt ->
+                val datagrunnlagKlassifisering = DatagrunnlagKlassifisering(
+                    inntekt.inntektType,
+                    inntekt.beskrivelse,
+                    inntekt.tilleggsinformasjon?.tilleggsinformasjonDetaljer?.spesielleInntjeningsforhold
+                )
 
-            val inntektKlasse = klassifiserInntekt(datagrunnlagKlassifisering)
-            KlassifisertInntekt(inntekt.beloep, inntektKlasse)
-        } ?: emptyList()
+                val inntektKlasse = klassifiserInntekt(datagrunnlagKlassifisering)
+                KlassifisertInntekt(inntekt.beloep, inntektKlasse)
+            } ?: emptyList()
         KlassifisertInntektMåned(årMåned, avvik.isNotEmpty(), klassifiserteInntekter)
     } ?: emptyList()
 }

--- a/src/test/kotlin/no/nav/dagpenger/inntekt/klassifisering/InntektsklassifiseringTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/inntekt/klassifisering/InntektsklassifiseringTest.kt
@@ -85,7 +85,12 @@ internal class InntektsklassifiseringTest {
 
         val klassifisertInntekt = klassifiserInntekter(inntektkomponentResponse)
         klassifisertInntekt.first().årMåned shouldBe now
-        klassifisertInntekt.first().klassifiserteInntekter shouldBe listOf(KlassifisertInntekt(100.toBigDecimal(), InntektKlasse.ARBEIDSINNTEKT))
+        klassifisertInntekt.first().klassifiserteInntekter shouldBe listOf(
+            KlassifisertInntekt(
+                100.toBigDecimal(),
+                InntektKlasse.ARBEIDSINNTEKT
+            )
+        )
     }
 
     @Test
@@ -108,7 +113,13 @@ internal class InntektsklassifiseringTest {
                                 inntektsperiodetype = "",
                                 inntektsstatus = "",
                                 utbetaltIMaaned = now,
-                                tilleggsinformasjon = TilleggInformasjon("", TilleggInformasjonsDetaljer("", SpesielleInntjeningsforhold.LOENN_VED_ARBEIDSMARKEDSTILTAK))
+                                tilleggsinformasjon = TilleggInformasjon(
+                                    "",
+                                    TilleggInformasjonsDetaljer(
+                                        "",
+                                        SpesielleInntjeningsforhold.LOENN_VED_ARBEIDSMARKEDSTILTAK
+                                    )
+                                )
                             )
                         )
                     )
@@ -120,7 +131,12 @@ internal class InntektsklassifiseringTest {
 
         val klassifisertInntekt = klassifiserInntekter(inntektkomponentResponse)
         klassifisertInntekt.first().årMåned shouldBe now
-        klassifisertInntekt.first().klassifiserteInntekter shouldBe listOf(KlassifisertInntekt(100.toBigDecimal(), InntektKlasse.TILTAKSLØNN))
+        klassifisertInntekt.first().klassifiserteInntekter shouldBe listOf(
+            KlassifisertInntekt(
+                100.toBigDecimal(),
+                InntektKlasse.TILTAKSLØNN
+            )
+        )
     }
 
     @Test
@@ -165,7 +181,109 @@ internal class InntektsklassifiseringTest {
 
         val klassifisertInntekt = klassifiserInntekter(inntektkomponentResponse)
         klassifisertInntekt.first().årMåned shouldBe now
-        klassifisertInntekt.first().klassifiserteInntekter shouldBe listOf(KlassifisertInntekt(100.toBigDecimal(), InntektKlasse.ARBEIDSINNTEKT))
+        klassifisertInntekt.first().klassifiserteInntekter shouldBe listOf(
+            KlassifisertInntekt(
+                100.toBigDecimal(),
+                InntektKlasse.ARBEIDSINNTEKT
+            )
+        )
+    }
+
+    @Test
+    fun `Skal skille ut avvik fra der avvik-info korrosponderer i inntektlista inntekt før en klassifiserer`() {
+        val now = YearMonth.now()
+        val aktør = Aktoer(AktoerType.AKTOER_ID, "1234")
+        val opplysningspliktig = Aktoer(AktoerType.ORGANISASJON, "12345678")
+        val inntektkomponentResponse = InntektkomponentResponse(
+            arbeidsInntektMaaned = listOf(
+                ArbeidsInntektMaaned(
+                    now,
+                    listOf(
+                        Avvik(
+                            ident = aktør,
+                            opplysningspliktig = opplysningspliktig,
+                            virksomhet = Aktoer(AktoerType.ORGANISASJON, "12345678"),
+                            avvikPeriode = now,
+                            tekst = "Avvik"
+
+                        )
+                    ),
+                    arbeidsInntektInformasjon = ArbeidsInntektInformasjon(
+                        inntektListe = listOf(
+                            Inntekt(
+                                beloep = 100.toBigDecimal(),
+                                beskrivelse = InntektBeskrivelse.FASTLOENN,
+                                opplysningspliktig = opplysningspliktig,
+                                fordel = "",
+                                inntektType = InntektType.LOENNSINNTEKT,
+                                inntektskilde = "",
+                                inntektsperiodetype = "",
+                                inntektsstatus = "",
+                                utbetaltIMaaned = now,
+                                inntektsmottaker = aktør
+
+                            )
+                        )
+                    )
+                )
+            ),
+            ident = aktør
+
+        )
+
+        val klassifisertInntekt = klassifiserInntekter(inntektkomponentResponse)
+        klassifisertInntekt.first().årMåned shouldBe now
+        klassifisertInntekt.first().klassifiserteInntekter shouldBe emptyList()
+    }
+
+    @Test
+    fun `Skal kun skille ut avvik fra inntekt hvis avvik info korrosponderer med inntektliste`() {
+        val now = YearMonth.now()
+        val aktør = Aktoer(AktoerType.AKTOER_ID, "1234")
+        val inntektkomponentResponse = InntektkomponentResponse(
+            arbeidsInntektMaaned = listOf(
+                ArbeidsInntektMaaned(
+                    now,
+                    listOf(
+                        Avvik(
+                            ident = Aktoer(AktoerType.AKTOER_ID, "ikke den samme som i inntektslista"),
+                            opplysningspliktig = Aktoer(AktoerType.ORGANISASJON, "12345678"),
+                            virksomhet = Aktoer(AktoerType.ORGANISASJON, "12345678"),
+                            avvikPeriode = now,
+                            tekst = "Avvik"
+
+                        )
+                    ),
+                    arbeidsInntektInformasjon = ArbeidsInntektInformasjon(
+                        inntektListe = listOf(
+                            Inntekt(
+                                beloep = 100.toBigDecimal(),
+                                beskrivelse = InntektBeskrivelse.FASTLOENN,
+                                fordel = "",
+                                inntektType = InntektType.LOENNSINNTEKT,
+                                inntektskilde = "",
+                                inntektsperiodetype = "",
+                                inntektsstatus = "",
+                                utbetaltIMaaned = now,
+                                inntektsmottaker = aktør
+
+                            )
+                        )
+                    )
+                )
+            ),
+            ident = aktør
+
+        )
+
+        val klassifisertInntekt = klassifiserInntekter(inntektkomponentResponse)
+        klassifisertInntekt.first().årMåned shouldBe now
+        klassifisertInntekt.first().klassifiserteInntekter shouldBe listOf(
+            KlassifisertInntekt(
+                100.toBigDecimal(),
+                InntektKlasse.ARBEIDSINNTEKT
+            )
+        )
     }
 
     @Test
@@ -177,7 +295,12 @@ internal class InntektsklassifiseringTest {
         val klassifisertInntekt = klassifiserInntekter(inntektkomponentResponse)
 
         klassifisertInntekt.first().harAvvik shouldBe true
-        klassifisertInntekt.first().klassifiserteInntekter shouldBe listOf(KlassifisertInntekt(1212.toBigDecimal(), InntektKlasse.ARBEIDSINNTEKT))
+        klassifisertInntekt.first().klassifiserteInntekter shouldBe listOf(
+            KlassifisertInntekt(
+                4321.toBigDecimal(),
+                InntektKlasse.ARBEIDSINNTEKT
+            )
+        )
     }
 
     @Test

--- a/src/test/resources/test-data/example-inntekt-avvik.json
+++ b/src/test/resources/test-data/example-inntekt-avvik.json
@@ -32,11 +32,37 @@
             "leveringstidspunkt": "2019-06",
             "utbetaltIMaaned": "2019-06",
             "opplysningspliktig": {
-              "identifikator": "12345678",
+              "identifikator": "123456789",
               "aktoerType": "ORGANISASJON"
             },
             "virksomhet": {
-              "identifikator": "12345678",
+              "identifikator": "123456789",
+              "aktoerType": "ORGANISASJON"
+            },
+            "inntektsmottaker": {
+              "identifikator": "12345678910",
+              "aktoerType": "NATURLIG_IDENT"
+            },
+            "inngaarIGrunnlagForTrekk": true,
+            "utloeserArbeidsgiveravgift": true,
+            "informasjonsstatus": "InngaarAlltid",
+            "beskrivelse": "fastloenn"
+          },
+          {
+            "inntektType": "LOENNSINNTEKT",
+            "beloep": 4321,
+            "fordel": "kontantytelse",
+            "inntektskilde": "A-ordningen",
+            "inntektsperiodetype": "Maaned",
+            "inntektsstatus": "LoependeInnrapportert",
+            "leveringstidspunkt": "2019-06",
+            "utbetaltIMaaned": "2019-06",
+            "opplysningspliktig": {
+              "identifikator": "987654321",
+              "aktoerType": "ORGANISASJON"
+            },
+            "virksomhet": {
+              "identifikator": "987654321",
               "aktoerType": "ORGANISASJON"
             },
             "inntektsmottaker": {


### PR DESCRIPTION
…exist in an income month, but will never appear as an income, but we filter out income from same origin (same business or organisation) if it exist in deviation list.

The month may contain income from other businesses that should be included. resolves navikt/dagpenger#131