### PR TITLE
Lagt til klient for bruk av oppslag tjenesten

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,7 +36,7 @@ java {
 val ktorVersion = "1.2.0"
 val fuelVersion = "2.1.0"
 val kotlinLoggingVersion = "1.6.22"
-val jupiterVersion = "5.3.2"
+val jupiterVersion = "5.4.1"
 val log4j2Version = "2.11.1"
 val prometheusVersion = "0.6.0"
 val moshiVersion = "1.8.0"

--- a/src/main/kotlin/no/nav/dagpenger/inntekt/mapping/GUIInntektsKomponentResponse.kt
+++ b/src/main/kotlin/no/nav/dagpenger/inntekt/mapping/GUIInntektsKomponentResponse.kt
@@ -15,7 +15,8 @@ data class GUIInntekt(
     val inntektId: InntektId,
     val timestamp: LocalDateTime?,
     val inntekt: GUIInntektsKomponentResponse,
-    val manueltRedigert: Boolean
+    val manueltRedigert: Boolean,
+    val naturligIdent: String? = null
 )
 
 data class GUIInntektsKomponentResponse(

--- a/src/main/kotlin/no/nav/dagpenger/inntekt/mapping/MapToGUIInntekt.kt
+++ b/src/main/kotlin/no/nav/dagpenger/inntekt/mapping/MapToGUIInntekt.kt
@@ -4,7 +4,7 @@ import no.nav.dagpenger.inntekt.db.StoredInntekt
 import no.nav.dagpenger.inntekt.klassifisering.DatagrunnlagKlassifisering
 import no.nav.dagpenger.inntekt.opptjeningsperiode.Opptjeningsperiode
 
-fun mapToGUIInntekt(storedInntekt: StoredInntekt, opptjeningsPeriode: Opptjeningsperiode): GUIInntekt {
+fun mapToGUIInntekt(storedInntekt: StoredInntekt, opptjeningsPeriode: Opptjeningsperiode, personnummer: String? = null): GUIInntekt {
     val mappedInntekt = storedInntekt.inntekt.arbeidsInntektMaaned?.map { arbeidsInntektMaaned ->
         GUIArbeidsInntektMaaned(
             arbeidsInntektMaaned.aarMaaned,
@@ -52,6 +52,7 @@ fun mapToGUIInntekt(storedInntekt: StoredInntekt, opptjeningsPeriode: Opptjening
             arbeidsInntektMaaned = mappedInntekt,
             ident = storedInntekt.inntekt.ident
         ),
-        storedInntekt.manueltRedigert
+        storedInntekt.manueltRedigert,
+        personnummer
     )
 }

--- a/src/main/kotlin/no/nav/dagpenger/inntekt/oppslag/OppslagClient.kt
+++ b/src/main/kotlin/no/nav/dagpenger/inntekt/oppslag/OppslagClient.kt
@@ -1,0 +1,33 @@
+package no.nav.dagpenger.inntekt.oppslag
+
+import com.github.kittinunf.fuel.core.extensions.authentication
+import com.github.kittinunf.fuel.httpGet
+import com.github.kittinunf.fuel.moshi.responseObject
+import mu.KotlinLogging
+import no.nav.dagpenger.oidc.OidcClient
+
+private val logger = KotlinLogging.logger {}
+class OppslagClient(val apiUrl: String, val oidcClient: OidcClient) {
+
+    fun finnNaturligIdent(aktørId: String): String? {
+        val url = "$apiUrl/naturlig-ident"
+        val (_, _, result) = with(url.httpGet()
+            .authentication().bearer(oidcClient.oidcToken().access_token)
+            .header(
+                mapOf(
+                    "ident" to aktørId
+                )
+            )) {
+            responseObject<NaturligIdent>()
+        }
+        return result.fold({
+            success -> success.naturligIdent
+        }, { error ->
+            logger.warn("Feil ved oppslag av personnummer", IdentOppslagException(error.response.statusCode, error.message ?: ""))
+            null
+        })
+    }
+}
+
+data class NaturligIdent(val naturligIdent: String)
+class IdentOppslagException(val statusCode: Int, override val message: String) : Exception(message)

--- a/src/main/kotlin/no/nav/dagpenger/inntekt/v1/UklassifisertInntektRoute.kt
+++ b/src/main/kotlin/no/nav/dagpenger/inntekt/v1/UklassifisertInntektRoute.kt
@@ -20,10 +20,15 @@ import no.nav.dagpenger.inntekt.mapping.GUIInntekt
 import no.nav.dagpenger.inntekt.mapping.dataGrunnlagKlassifiseringToVerdikode
 import no.nav.dagpenger.inntekt.mapping.mapFromGUIInntekt
 import no.nav.dagpenger.inntekt.mapping.mapToGUIInntekt
+import no.nav.dagpenger.inntekt.oppslag.OppslagClient
 import no.nav.dagpenger.inntekt.opptjeningsperiode.Opptjeningsperiode
 import java.time.LocalDate
 
-fun Route.uklassifisertInntekt(inntektskomponentClient: InntektskomponentClient, inntektStore: InntektStore) {
+fun Route.uklassifisertInntekt(
+    inntektskomponentClient: InntektskomponentClient,
+    inntektStore: InntektStore,
+    oppslagClient: OppslagClient
+) {
     authenticate("jwt") {
         route("/uklassifisert/{aktørId}/{vedtakId}/{beregningsDato}") {
             get {
@@ -36,11 +41,11 @@ fun Route.uklassifisertInntekt(inntektskomponentClient: InntektskomponentClient,
                 } catch (e: Exception) {
                     throw IllegalArgumentException("Failed to parse parameters", e)
                 }
-
+                val personNummer = oppslagClient.finnNaturligIdent(request.aktørId)
                 val opptjeningsperiode = Opptjeningsperiode(request.beregningsDato)
                 val storedInntekt = inntektStore.getInntektId(request)?.let { inntektStore.getInntekt(it) }
                     ?: throw InntektNotFoundException("Inntekt with for $request not found.")
-                val mappedInntekt = mapToGUIInntekt(storedInntekt, opptjeningsperiode)
+                val mappedInntekt = mapToGUIInntekt(storedInntekt, opptjeningsperiode, personNummer)
                 call.respond(HttpStatusCode.OK, mappedInntekt)
             }
         }
@@ -58,10 +63,12 @@ fun Route.uklassifisertInntekt(inntektskomponentClient: InntektskomponentClient,
                 }
 
                 val opptjeningsperiode = Opptjeningsperiode(request.beregningsDato)
+                val personNummer = oppslagClient.finnNaturligIdent(request.aktørId)
+
                 val uncachedInntekt =
                     inntektskomponentClient.getInntekt(toInntektskomponentRequest(request, opptjeningsperiode))
                 val storedInntekt = inntektStore.insertInntekt(request, uncachedInntekt)
-                val mappedInntekt = mapToGUIInntekt(storedInntekt, opptjeningsperiode)
+                val mappedInntekt = mapToGUIInntekt(storedInntekt, opptjeningsperiode, personNummer)
                 call.respond(HttpStatusCode.OK, mappedInntekt)
             }
         }
@@ -73,7 +80,7 @@ fun Route.uklassifisertInntekt(inntektskomponentClient: InntektskomponentClient,
                 val storedInntekt = inntektStore.redigerInntekt(mappedInntekt)
                 val key = inntektStore.getInntektCompoundKey(storedInntekt.inntektId)
                 val opptjeningsperiode: Opptjeningsperiode = Opptjeningsperiode(key.beregningsDato)
-                call.respond(HttpStatusCode.OK, mapToGUIInntekt(storedInntekt, opptjeningsperiode))
+                call.respond(HttpStatusCode.OK, mapToGUIInntekt(storedInntekt, opptjeningsperiode, request.naturligIdent))
             }
         }
     }

--- a/src/test/kotlin/no/nav/dagpenger/inntekt/mapping/MapToFromGUIInntektTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/inntekt/mapping/MapToFromGUIInntektTest.kt
@@ -93,6 +93,8 @@ val rawInntekt = InntektkomponentResponse(
     Aktoer(AktoerType.AKTOER_ID, "aktorId")
 )
 
+val testPnr = "12345678912"
+
 val inntektMedVerdikode = GUIArbeidsInntektInformasjon(
         listOf(InntektMedVerdikode(
                 BigDecimal.ONE,
@@ -116,19 +118,19 @@ internal class KategoriseringTest {
             false,
             LocalDateTime.now()
         )
-        val guiInntekt = mapToGUIInntekt(storedInntekt, Opptjeningsperiode(LocalDate.now()))
+        val guiInntekt = mapToGUIInntekt(storedInntekt, Opptjeningsperiode(LocalDate.now()), testPnr)
         assertEquals(
             "Aksjer/grunnfondsbevis til underkurs",
             guiInntekt.inntekt.arbeidsInntektMaaned?.first()?.arbeidsInntektInformasjon?.inntektListe?.first()?.verdikode
         )
         assertEquals(
             "Fastlønn",
-            guiInntekt.inntekt.arbeidsInntektMaaned?.filter {
+            guiInntekt.inntekt.arbeidsInntektMaaned?.first {
                 it.aarMaaned == YearMonth.of(
                     2019,
                     6
                 )
-            }?.first()?.arbeidsInntektInformasjon?.inntektListe?.first()?.verdikode
+            }?.arbeidsInntektInformasjon?.inntektListe?.first()?.verdikode
         )
         assertEquals(
             "Hyre - Annet",
@@ -149,7 +151,7 @@ internal class KategoriseringTest {
             false,
             LocalDateTime.now()
         )
-        val guiInntekt = mapToGUIInntekt(storedInntekt, Opptjeningsperiode(LocalDate.now()))
+        val guiInntekt = mapToGUIInntekt(storedInntekt, Opptjeningsperiode(LocalDate.now()), testPnr)
 
         assertNotNull(guiInntekt.inntekt.fraDato)
         assertNotNull(guiInntekt.inntekt.tilDato)
@@ -163,7 +165,7 @@ internal class KategoriseringTest {
             false,
             LocalDateTime.now()
         )
-        val guiInntekt = mapToGUIInntekt(storedInntekt, Opptjeningsperiode(LocalDate.now()))
+        val guiInntekt = mapToGUIInntekt(storedInntekt, Opptjeningsperiode(LocalDate.now()), testPnr)
 
         val beforeJson = moshiInstance.adapter(InntektkomponentResponse::class.java).toJson(rawInntekt)
         val mappedJson = moshiInstance.adapter(GUIInntektsKomponentResponse::class.java).toJson(guiInntekt.inntekt)
@@ -242,7 +244,7 @@ internal class KategoriseringTest {
             LocalDateTime.now()
         )
 
-        val mapFromGUIInntekt = mapFromGUIInntekt(mapToGUIInntekt(storedInntekt, Opptjeningsperiode(LocalDate.now())))
+        val mapFromGUIInntekt = mapFromGUIInntekt(mapToGUIInntekt(storedInntekt, Opptjeningsperiode(LocalDate.now()), testPnr))
         assertEquals(storedInntekt.manueltRedigert, mapFromGUIInntekt.manueltRedigert)
         assertEquals(storedInntekt.inntekt, mapFromGUIInntekt.inntekt)
         assertEquals(storedInntekt.inntektId, mapFromGUIInntekt.inntektId)

--- a/src/test/kotlin/no/nav/dagpenger/inntekt/oppslag/OppslagClientTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/inntekt/oppslag/OppslagClientTest.kt
@@ -1,0 +1,73 @@
+package no.nav.dagpenger.inntekt.oppslag
+
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.WireMock
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration
+import com.github.tomakehurst.wiremock.matching.AnythingPattern
+import no.nav.dagpenger.oidc.OidcClient
+import no.nav.dagpenger.oidc.OidcToken
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+class OppslagClientTest {
+    val validResponse = """{
+        |"naturligIdent": "12345678912"
+        |}""".trimMargin()
+
+    lateinit var wiremockServer: WireMockServer
+    val oidcClient = object : OidcClient {
+        override fun oidcToken(): OidcToken {
+            return OidcToken(UUID.randomUUID().toString(), "openid", 3000)
+        }
+    }
+    companion object {
+        val server = WireMockServer(WireMockConfiguration.options().dynamicPort())
+
+        @BeforeAll
+        @JvmStatic
+        fun start() {
+            server.start()
+        }
+
+        @AfterAll
+        @JvmStatic
+        fun stop() {
+            server.stop()
+        }
+    }
+
+    @BeforeEach
+    fun setup() {
+        WireMock.configureFor(server.port())
+    }
+
+    @Test
+    fun `fetches person naturlig-ident on 200 OK`() {
+        val oppslagClient = OppslagClient(server.url(""), oidcClient)
+        WireMock.stubFor(
+            WireMock.get(WireMock.urlEqualTo("//naturlig-ident"))
+                .withHeader("ident", AnythingPattern())
+                .willReturn(WireMock.aResponse().withBody(validResponse))
+        )
+
+        val pnr = oppslagClient.finnNaturligIdent("1234")
+        assertEquals("12345678912", pnr)
+    }
+
+    @Test
+    fun `returns empty string if something goes wrong`() {
+        val oppslagClient = OppslagClient(server.url(""), oidcClient)
+        WireMock.stubFor(
+            WireMock.get(WireMock.urlEqualTo("//naturlig-ident"))
+                .withHeader("ident", AnythingPattern())
+                .willReturn(WireMock.serverError())
+        )
+        val pnr = oppslagClient.finnNaturligIdent("1234")
+        assertNull(pnr)
+    }
+}

--- a/src/test/kotlin/no/nav/dagpenger/inntekt/v1/AktørApiTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/inntekt/v1/AktørApiTest.kt
@@ -12,6 +12,7 @@ import io.mockk.mockk
 import no.nav.dagpenger.inntekt.brreg.enhetsregisteret.EnhetsregisteretHttpClient
 import no.nav.dagpenger.inntekt.inntektApi
 import no.nav.dagpenger.inntekt.inntektskomponenten.v1.InntektskomponentClient
+import no.nav.dagpenger.inntekt.oppslag.OppslagClient
 import no.nav.dagpenger.inntekt.oppslag.PersonNameHttpClient
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
@@ -34,11 +35,15 @@ class AktørApiTest {
     private val inntektskomponentClientMock: InntektskomponentClient = mockk()
     private val enhetsregisteretHttpClientMock: EnhetsregisteretHttpClient = mockk()
     private val personNameHttpClientMock: PersonNameHttpClient = mockk()
+    private val oppslagClientMock: OppslagClient = mockk()
 
     init {
         every {
             enhetsregisteretHttpClientMock.getOrgName(any())
         } returns "123456789"
+        every {
+            oppslagClientMock.finnNaturligIdent(any())
+        } returns "12345678912"
     }
 
     @Test
@@ -70,6 +75,7 @@ class AktørApiTest {
                 mockk(relaxed = true),
                 enhetsregisteretHttpClientMock,
                 personNameHttpClientMock,
+                oppslagClientMock,
                 mockk(relaxed = true),
                 mockk(relaxed = true)))
         }) { callback() }

--- a/src/test/kotlin/no/nav/dagpenger/inntekt/v1/KlassifisertInntektApiTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/inntekt/v1/KlassifisertInntektApiTest.kt
@@ -1,6 +1,5 @@
 package no.nav.dagpenger.inntekt.v1
 
-import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpMethod
 import io.ktor.http.HttpStatusCode
@@ -24,6 +23,7 @@ import no.nav.dagpenger.inntekt.inntektskomponenten.v1.InntektkomponentResponse
 import no.nav.dagpenger.inntekt.inntektskomponenten.v1.InntektskomponentClient
 import no.nav.dagpenger.inntekt.inntektskomponenten.v1.InntektskomponentenHttpClientException
 import no.nav.dagpenger.inntekt.moshiInstance
+import no.nav.dagpenger.inntekt.oppslag.OppslagClient
 import no.nav.dagpenger.inntekt.oppslag.PersonNameHttpClient
 import no.nav.dagpenger.ktor.auth.ApiKeyVerifier
 import org.junit.jupiter.api.Test
@@ -52,6 +52,7 @@ class KlassifisertInntektApiTest {
     private val inntektskomponentClientMock: InntektskomponentClient = mockk()
     private val enhetsregisteretHttpClientMock: EnhetsregisteretHttpClient = mockk()
     private val personNameHttpClientMock: PersonNameHttpClient = mockk()
+    private val oppslagClientMock: OppslagClient = mockk()
     private val inntektStoreMock: InntektStore = mockk(relaxed = true)
     private val inntektPath = "/v1/inntekt"
 
@@ -81,6 +82,9 @@ class KlassifisertInntektApiTest {
         every {
             inntektStoreMock.getInntektId(any())
         } returns null
+        every {
+            oppslagClientMock.finnNaturligIdent(any())
+        } returns "12345678912"
     }
 
     @Test
@@ -217,6 +221,7 @@ class KlassifisertInntektApiTest {
                 inntektStoreMock,
                 enhetsregisteretHttpClientMock,
                 personNameHttpClientMock,
+                oppslagClientMock,
                 authApiKeyVerifier,
                 mockk(relaxed = true)
             ))

--- a/src/test/kotlin/no/nav/dagpenger/inntekt/v1/OpptjeningsperiodeApiSpec.kt
+++ b/src/test/kotlin/no/nav/dagpenger/inntekt/v1/OpptjeningsperiodeApiSpec.kt
@@ -31,6 +31,7 @@ class OpptjeningsperiodeApiSpec {
                 inntektStore,
                 mockk(),
                 mockk(),
+                mockk(),
                 mockk(relaxed = true),
                 mockk(relaxed = true)
             )

--- a/src/test/kotlin/no/nav/dagpenger/inntekt/v1/UklassifisertInntektApiTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/inntekt/v1/UklassifisertInntektApiTest.kt
@@ -24,6 +24,7 @@ import no.nav.dagpenger.inntekt.inntektskomponenten.v1.InntektkomponentRequest
 import no.nav.dagpenger.inntekt.inntektskomponenten.v1.InntektkomponentResponse
 import no.nav.dagpenger.inntekt.inntektskomponenten.v1.InntektskomponentClient
 import no.nav.dagpenger.inntekt.moshiInstance
+import no.nav.dagpenger.inntekt.oppslag.OppslagClient
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
@@ -52,7 +53,7 @@ class UklassifisertInntektApiTest {
         YearMonth.of(2015, 12),
         YearMonth.of(2018, 12)
     )
-
+    private val oppslagClientMock: OppslagClient = mockk()
     private val emptyInntekt = InntektkomponentResponse(emptyList(), Aktoer(AktoerType.AKTOER_ID, "1234"))
 
     private val storedInntekt = StoredInntekt(
@@ -97,6 +98,10 @@ class UklassifisertInntektApiTest {
         every {
             inntektskomponentClientMock.getInntekt(inntektkomponentenFoundRequest)
         } returns emptyInntekt
+
+        every {
+            oppslagClientMock.finnNaturligIdent(any())
+        } returns "12345678912"
     }
 
     @Test
@@ -226,7 +231,7 @@ class UklassifisertInntektApiTest {
 
     private fun testApp(callback: TestApplicationEngine.() -> Unit) {
         withTestApplication({
-            (inntektApi(inntektskomponentClientMock, inntektStoreMock, mockk(), mockk(), mockk(relaxed = true), jwkProvider = jwtStub.stubbedJwkProvider()))
+            (inntektApi(inntektskomponentClientMock, inntektStoreMock, mockk(), mockk(), oppslagClientMock, mockk(relaxed = true), jwkProvider = jwtStub.stubbedJwkProvider()))
         }) { callback() }
     }
 }


### PR DESCRIPTION
Som diskutert i går. Denne gjør oppslag mot dagpenger-oppslag for å hente naturlig-ident / personnummer. 
Embeddes så i objektet vi returnerer til GUI på topp nivå.

Føles som en smell at vi blander inn aktør informasjon i inntektobjektet.

En annen ting er at vi kanskje bør utvide kallet i oppslag tjenesten til også å returnere navn. Men i første omgang gjør vi dette.