### PR TITLE
Fjern ubrukte inntekter etter 3 måneder (#68)

### DIFF
--- a/src/main/kotlin/no/nav/dagpenger/inntekt/Configuration.kt
+++ b/src/main/kotlin/no/nav/dagpenger/inntekt/Configuration.kt
@@ -4,6 +4,7 @@ import com.natpryce.konfig.ConfigurationMap
 import com.natpryce.konfig.ConfigurationProperties
 import com.natpryce.konfig.EnvironmentVariables
 import com.natpryce.konfig.Key
+import com.natpryce.konfig.booleanType
 import com.natpryce.konfig.intType
 import com.natpryce.konfig.overriding
 import com.natpryce.konfig.stringType
@@ -31,7 +32,8 @@ private val localProperties = ConfigurationMap(
         "api.secret" to "secret",
         "api.keys" to "dp-datalaster-inntekt",
         "kafka.subsumsjon.brukt.data.topic" to "privat-dagpenger-subsumsjon-brukt-data",
-        "kafka.bootstrap.servers" to "localhost:9092"
+        "kafka.bootstrap.servers" to "localhost:9092",
+        "vaktmester.aktiv" to true.toString()
 
     )
 )
@@ -51,7 +53,8 @@ private val devProperties = ConfigurationMap(
         "application.profile" to "DEV",
         "application.httpPort" to "8099",
         "kafka.subsumsjon.brukt.data.topic" to "privat-dagpenger-subsumsjon-brukt-data",
-        "kafka.bootstrap.servers" to "b27apvl00045.preprod.local:8443,b27apvl00046.preprod.local:8443,b27apvl00047.preprod.local:8443"
+        "kafka.bootstrap.servers" to "b27apvl00045.preprod.local:8443,b27apvl00046.preprod.local:8443,b27apvl00047.preprod.local:8443",
+        "vaktmester.aktiv" to true.toString()
     )
 )
 private val prodProperties = ConfigurationMap(
@@ -79,9 +82,11 @@ data class Configuration(
     val vault: Vault = Vault(),
     val application: Application = Application(),
     val kafka: Kafka = Kafka(),
-    val subsumsjonBruktDataTopic: String = config()[Key("kafka.subsumsjon.brukt.data.topic", stringType)]
+    val subsumsjonBruktDataTopic: String = config()[Key("kafka.subsumsjon.brukt.data.topic", stringType)],
+    val aktivVaktmester: Boolean = config().getOrElse(Key("vaktmester.aktiv", booleanType), false)
 
 ) {
+
     data class Database(
         val host: String = config()[Key("database.host", stringType)],
         val port: String = config()[Key("database.port", stringType)],

--- a/src/main/kotlin/no/nav/dagpenger/inntekt/InntektApi.kt
+++ b/src/main/kotlin/no/nav/dagpenger/inntekt/InntektApi.kt
@@ -42,7 +42,8 @@ import no.nav.dagpenger.inntekt.inntektskomponenten.v1.InntektskomponentClient
 import no.nav.dagpenger.inntekt.inntektskomponenten.v1.InntektskomponentHttpClient
 import no.nav.dagpenger.inntekt.inntektskomponenten.v1.InntektskomponentenHttpClientException
 import no.nav.dagpenger.inntekt.oppslag.OppslagClient
-import no.nav.dagpenger.inntekt.subasumsjonbrukt.KafkaSubsumsjonBruktDataConsumer
+import no.nav.dagpenger.inntekt.subsumsjonbrukt.KafkaSubsumsjonBruktDataConsumer
+import no.nav.dagpenger.inntekt.subsumsjonbrukt.Vaktmester
 import no.nav.dagpenger.inntekt.v1.InntektNotAuthorizedException
 import no.nav.dagpenger.inntekt.v1.klassifisertInntekt
 import no.nav.dagpenger.inntekt.v1.opptjeningsperiodeApi
@@ -57,6 +58,7 @@ import org.slf4j.event.Level
 import java.net.URI
 import java.net.URL
 import java.util.concurrent.TimeUnit
+import kotlin.concurrent.fixedRateTimer
 
 private val LOGGER = KotlinLogging.logger {}
 val config = Configuration()
@@ -72,12 +74,27 @@ fun main() = runBlocking {
     val apiKeyVerifier = ApiKeyVerifier(config.application.apiSecret)
     val allowedApiKeys = config.application.allowedApiKeys
 
-    val postgresInntektStore = PostgresInntektStore(dataSourceFrom(config))
+    val dataSource = dataSourceFrom(config)
+    val postgresInntektStore = PostgresInntektStore(dataSource)
     val stsOidcClient =
         StsOidcClient(config.application.oicdStsUrl, config.application.username, config.application.password)
 
     val subsumsjonBruktDataConsumer = KafkaSubsumsjonBruktDataConsumer(config, postgresInntektStore).apply {
         listen()
+    }
+
+    val vaktmester = Vaktmester(dataSource)
+
+    if (config.aktivVaktmester) {
+        val timer = fixedRateTimer(
+            name = "vaktmester",
+            initialDelay = TimeUnit.MINUTES.toMillis(10),
+            period = TimeUnit.HOURS.toMillis(12),
+            action = {
+                LOGGER.info { "Vaktmesteren rydder" }
+                vaktmester.rydd()
+                LOGGER.info { "Vaktmesteren er ferdig... for denne gang" }
+            })
     }
 
     val inntektskomponentHttpClient = InntektskomponentHttpClient(

--- a/src/main/kotlin/no/nav/dagpenger/inntekt/db/InntektStore.kt
+++ b/src/main/kotlin/no/nav/dagpenger/inntekt/db/InntektStore.kt
@@ -5,13 +5,14 @@ import no.nav.dagpenger.inntekt.BehandlingsKey
 import no.nav.dagpenger.inntekt.inntektskomponenten.v1.InntektkomponentResponse
 import java.time.LocalDate
 import java.time.LocalDateTime
+import java.time.ZoneOffset
+import java.time.ZonedDateTime
 
 interface InntektStore {
     fun getInntekt(inntektId: InntektId): StoredInntekt
     fun getInntektId(request: BehandlingsKey): InntektId?
     fun getBeregningsdato(inntektId: InntektId): LocalDate
-    fun insertInntekt(request: BehandlingsKey, inntekt: InntektkomponentResponse, manueltRedigert: ManueltRedigert?): StoredInntekt
-    fun insertInntekt(request: BehandlingsKey, inntekt: InntektkomponentResponse): StoredInntekt
+    fun insertInntekt(request: BehandlingsKey, inntekt: InntektkomponentResponse, manueltRedigert: ManueltRedigert? = null, created: ZonedDateTime = ZonedDateTime.now(ZoneOffset.UTC)): StoredInntekt
     fun getManueltRedigert(inntektId: InntektId): ManueltRedigert?
     fun markerInntektBrukt(inntektId: InntektId): Int
 }

--- a/src/main/kotlin/no/nav/dagpenger/inntekt/subsumsjonbrukt/KafkaSubsumsjonBruktDataConsumer.kt
+++ b/src/main/kotlin/no/nav/dagpenger/inntekt/subsumsjonbrukt/KafkaSubsumsjonBruktDataConsumer.kt
@@ -1,4 +1,4 @@
-package no.nav.dagpenger.inntekt.subasumsjonbrukt
+package no.nav.dagpenger.inntekt.subsumsjonbrukt
 
 import io.prometheus.client.Summary
 import kotlinx.coroutines.CoroutineExceptionHandler

--- a/src/main/kotlin/no/nav/dagpenger/inntekt/subsumsjonbrukt/Vaktmester.kt
+++ b/src/main/kotlin/no/nav/dagpenger/inntekt/subsumsjonbrukt/Vaktmester.kt
@@ -1,0 +1,34 @@
+package no.nav.dagpenger.inntekt.subsumsjonbrukt
+
+import io.prometheus.client.Counter
+import kotliquery.queryOf
+import kotliquery.sessionOf
+import kotliquery.using
+import javax.sql.DataSource
+
+const val INNTEKT_SLETTET = "inntekt_slettet"
+private val deleteCounter = Counter.build()
+    .name(INNTEKT_SLETTET)
+    .help("Antall inntektsett slettet fra databasen")
+    .register()
+
+class Vaktmester(private val dataSource: DataSource, private val lifeSpanInDays: Int = 90) {
+
+    fun rydd() {
+        val rowCount =
+            using(sessionOf(dataSource)) { session ->
+            session.transaction { transaction ->
+                transaction.run(
+                    queryOf(
+                        """
+                            DELETE FROM inntekt_v1 WHERE brukt = false AND timestamp  < (now() - (make_interval(days := :days)))
+                        """.trimIndent(), mapOf(
+                            "days" to lifeSpanInDays
+                        )
+                    ).asUpdate
+                )
+            }
+        }
+        deleteCounter.inc(rowCount.toDouble())
+    }
+}

--- a/src/main/resources/db/migration/V1_6__INNTEKT_ARENA_MAPPING_DELETE_CASCADE.sql
+++ b/src/main/resources/db/migration/V1_6__INNTEKT_ARENA_MAPPING_DELETE_CASCADE.sql
@@ -1,0 +1,3 @@
+ALTER TABLE inntekt_v1_arena_mapping
+    DROP CONSTRAINT inntekt_v1_arena_mapping_inntektid_fkey,
+    ADD CONSTRAINT inntekt_v1_arena_mapping_inntektid_fkey FOREIGN KEY (inntektid) REFERENCES inntekt_v1 (id) ON DELETE CASCADE;

--- a/src/test/kotlin/no/nav/dagpenger/inntekt/CachedInntektsGetterTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/inntekt/CachedInntektsGetterTest.kt
@@ -81,14 +81,14 @@ class CachedInntektsGetterTest {
         } returns null
 
         every {
-            inntektStoreMock.insertInntekt(unknownBehandlingsKey, emptyInntektsKomponentResponse)
+            inntektStoreMock.insertInntekt(unknownBehandlingsKey, emptyInntektsKomponentResponse, any(), any())
         } returns StoredInntekt(InntektId("01DH179R2HW0FYEP1FABAXV150"), emptyInntektsKomponentResponse, false)
 
         val cachedInntektsGetter = BehandlingsInntektsGetter(inntektskomponentClientMock, inntektStoreMock)
         val storedInntektResult = runBlocking { cachedInntektsGetter.getBehandlingsInntekt(unknownBehandlingsKey) }
 
         verify(exactly = 1) { runBlocking { inntektskomponentClientMock.getInntekt(any()) } }
-        verify(exactly = 1) { runBlocking { inntektStoreMock.insertInntekt(any(), any()) } }
+        verify(exactly = 1) { runBlocking { inntektStoreMock.insertInntekt(any(), any(), any(), any()) } }
         assertEquals(emptyInntektsKomponentResponse.ident, storedInntektResult.inntekt.ident)
     }
 }

--- a/src/test/kotlin/no/nav/dagpenger/inntekt/PostgresSetup.kt
+++ b/src/test/kotlin/no/nav/dagpenger/inntekt/PostgresSetup.kt
@@ -1,0 +1,30 @@
+package no.nav.dagpenger.inntekt
+
+import com.zaxxer.hikari.HikariDataSource
+import no.nav.dagpenger.inntekt.db.clean
+import no.nav.dagpenger.inntekt.db.migrate
+import org.testcontainers.containers.PostgreSQLContainer
+
+fun withCleanDb(test: () -> Unit) = DataSource.instance.also { clean(it) }.run { test() }
+
+fun withMigratedDb(test: () -> Unit) =
+    DataSource.instance.also { clean(it) }.also { migrate(it) }.run { test() }
+
+object PostgresContainer {
+    val instance by lazy {
+        PostgreSQLContainer<Nothing>("postgres:11.2").apply {
+            start()
+        }
+    }
+}
+
+object DataSource {
+    val instance: HikariDataSource by lazy {
+        HikariDataSource().apply {
+            username = PostgresContainer.instance.username
+            password = PostgresContainer.instance.password
+            jdbcUrl = PostgresContainer.instance.jdbcUrl
+            connectionTimeout = 1000L
+        }
+    }
+}

--- a/src/test/kotlin/no/nav/dagpenger/inntekt/db/PostgresTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/inntekt/db/PostgresTest.kt
@@ -1,16 +1,17 @@
 package no.nav.dagpenger.inntekt.db
 
-import com.zaxxer.hikari.HikariDataSource
 import io.kotlintest.shouldBe
 import no.nav.dagpenger.inntekt.BehandlingsKey
 import no.nav.dagpenger.inntekt.Configuration
+import no.nav.dagpenger.inntekt.DataSource
 import no.nav.dagpenger.inntekt.dummyConfigs
 import no.nav.dagpenger.inntekt.inntektskomponenten.v1.Aktoer
 import no.nav.dagpenger.inntekt.inntektskomponenten.v1.AktoerType
 import no.nav.dagpenger.inntekt.inntektskomponenten.v1.InntektkomponentResponse
+import no.nav.dagpenger.inntekt.withCleanDb
+import no.nav.dagpenger.inntekt.withMigratedDb
 import no.nav.dagpenger.inntekt.withProps
 import org.junit.Test
-import org.testcontainers.containers.PostgreSQLContainer
 import java.time.LocalDate
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -24,7 +25,7 @@ internal class PostgresTest {
     fun `Migration scripts are applied successfully`() {
         withCleanDb {
             val migrations = migrate(DataSource.instance)
-            assertEquals(6, migrations, "Wrong number of migrations")
+            assertEquals(7, migrations, "Wrong number of migrations")
         }
     }
 
@@ -42,7 +43,7 @@ internal class PostgresTest {
     fun `Migration of testdata `() {
         withCleanDb {
             val migrations = migrate(DataSource.instance, locations = listOf("db/migration", "db/testdata"))
-            assertEquals(10, migrations, "Wrong number of migrations")
+            assertEquals(11, migrations, "Wrong number of migrations")
         }
     }
 
@@ -178,7 +179,6 @@ internal class PostgresInntektStoreTest {
 
     @Test
     fun ` Getting beregningsdato for unknown inntektId should throw error`() {
-
         withMigratedDb {
             with(PostgresInntektStore(DataSource.instance)) {
                 val result = runCatching {
@@ -191,7 +191,6 @@ internal class PostgresInntektStoreTest {
     }
     @Test
     fun ` Should mark an inntekt as used `() {
-
         withMigratedDb {
             with(PostgresInntektStore(DataSource.instance)) {
                 val hentInntektListeResponse = InntektkomponentResponse(
@@ -200,34 +199,8 @@ internal class PostgresInntektStoreTest {
                 )
                 val storedInntekt = insertInntekt(BehandlingsKey("1234", 12345, LocalDate.now()), hentInntektListeResponse)
                 val updated = markerInntektBrukt(storedInntekt.inntektId)
-                val updatedSecond = markerInntektBrukt(storedInntekt.inntektId)
                 updated shouldBe 1
-                updatedSecond shouldBe 0
             }
-        }
-    }
-}
-
-private fun withCleanDb(test: () -> Unit) = DataSource.instance.also { clean(it) }.run { test() }
-
-private fun withMigratedDb(test: () -> Unit) =
-    DataSource.instance.also { clean(it) }.also { migrate(it) }.run { test() }
-
-private object PostgresContainer {
-    val instance by lazy {
-        PostgreSQLContainer<Nothing>("postgres:11.2").apply {
-            start()
-        }
-    }
-}
-
-private object DataSource {
-    val instance: HikariDataSource by lazy {
-        HikariDataSource().apply {
-            username = PostgresContainer.instance.username
-            password = PostgresContainer.instance.password
-            jdbcUrl = PostgresContainer.instance.jdbcUrl
-            connectionTimeout = 1000L
         }
     }
 }

--- a/src/test/kotlin/no/nav/dagpenger/inntekt/subsumsjonbrukt/KafkaSubsumsjonBruktDataConsumerTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/inntekt/subsumsjonbrukt/KafkaSubsumsjonBruktDataConsumerTest.kt
@@ -12,7 +12,6 @@ import no.nav.dagpenger.inntekt.Configuration
 import no.nav.dagpenger.inntekt.HealthStatus
 import no.nav.dagpenger.inntekt.db.InntektId
 import no.nav.dagpenger.inntekt.db.InntektStore
-import no.nav.dagpenger.inntekt.subasumsjonbrukt.KafkaSubsumsjonBruktDataConsumer
 import no.nav.dagpenger.plain.producerConfig
 import org.apache.kafka.clients.producer.KafkaProducer
 import org.apache.kafka.clients.producer.ProducerConfig

--- a/src/test/kotlin/no/nav/dagpenger/inntekt/subsumsjonbrukt/VaktmesterTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/inntekt/subsumsjonbrukt/VaktmesterTest.kt
@@ -1,0 +1,107 @@
+package no.nav.dagpenger.inntekt.subsumsjonbrukt
+
+import io.kotlintest.matchers.doubles.shouldBeGreaterThan
+import io.kotlintest.shouldBe
+import io.kotlintest.shouldNotBe
+import io.prometheus.client.CollectorRegistry
+import no.nav.dagpenger.inntekt.BehandlingsKey
+import no.nav.dagpenger.inntekt.DataSource
+import no.nav.dagpenger.inntekt.db.InntektNotFoundException
+import no.nav.dagpenger.inntekt.db.PostgresInntektStore
+import no.nav.dagpenger.inntekt.inntektskomponenten.v1.Aktoer
+import no.nav.dagpenger.inntekt.inntektskomponenten.v1.AktoerType
+import no.nav.dagpenger.inntekt.inntektskomponenten.v1.ArbeidsInntektInformasjon
+import no.nav.dagpenger.inntekt.inntektskomponenten.v1.ArbeidsInntektMaaned
+import no.nav.dagpenger.inntekt.inntektskomponenten.v1.InntektkomponentResponse
+import no.nav.dagpenger.inntekt.withMigratedDb
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.time.LocalDate
+import java.time.YearMonth
+import java.time.ZonedDateTime
+
+internal class VaktmesterTest {
+
+    private val behandlingsKey = BehandlingsKey(
+        aktørId = "1234",
+        vedtakId = 1234,
+        beregningsDato = LocalDate.now()
+    )
+
+    private val inntekter = InntektkomponentResponse(
+        ident = Aktoer(AktoerType.AKTOER_ID, behandlingsKey.aktørId),
+        arbeidsInntektMaaned = emptyList()
+    )
+
+    @Test
+    fun `Skal ikke slette brukte inntekter`() {
+
+        withMigratedDb {
+            val inntektStore = PostgresInntektStore(DataSource.instance)
+            val bruktInntekt = inntektStore.insertInntekt(
+                request = behandlingsKey,
+                inntekt = inntekter
+            )
+            inntektStore.markerInntektBrukt(bruktInntekt.inntektId)
+            val vaktmester = Vaktmester(DataSource.instance)
+            vaktmester.rydd()
+            inntektStore.getInntekt(bruktInntekt.inntektId) shouldNotBe null
+        }
+    }
+
+    @Test
+    fun `Skal kun slette inntekt som ikke er brukt selvom det er referrert til samme behandlingsnøkler som en annen inntekt som er brukt`() {
+        withMigratedDb {
+            val inntektStore = PostgresInntektStore(DataSource.instance)
+            val ubruktInntekt = inntektStore.insertInntekt(
+                request = behandlingsKey,
+                inntekt = inntekter,
+                created = ZonedDateTime.now().minusMonths(4)
+            )
+            val bruktInntekt = inntektStore.insertInntekt(
+                request = behandlingsKey,
+                inntekt = inntekter.copy(
+                    arbeidsInntektMaaned = listOf(
+                        ArbeidsInntektMaaned(
+                            aarMaaned = YearMonth.now(),
+                            arbeidsInntektInformasjon = ArbeidsInntektInformasjon(emptyList()),
+                            avvikListe = emptyList()
+                        )
+                    )
+                ),
+                created = ZonedDateTime.now().minusMonths(4)
+            )
+            inntektStore.markerInntektBrukt(bruktInntekt.inntektId)
+            val vaktmester = Vaktmester(DataSource.instance)
+            vaktmester.rydd()
+            inntektStore.getInntektId(behandlingsKey) shouldBe bruktInntekt.inntektId
+            assertThrows<InntektNotFoundException> { inntektStore.getInntekt(ubruktInntekt.inntektId) }
+        }
+    }
+
+    @Test
+    fun `Skal kun slette ubrukte inntekter som er eldre enn 90 dager`() {
+        withMigratedDb {
+            val inntektStore = PostgresInntektStore(DataSource.instance)
+            val ubruktEldreEnn90Dager = inntektStore.insertInntekt(
+                request = behandlingsKey,
+                inntekt = inntekter,
+                created = ZonedDateTime.now().minusMonths(4)
+            )
+            val ubruktYngreEnn90Dager = inntektStore.insertInntekt(
+                request = behandlingsKey,
+                inntekt = inntekter
+            )
+
+            val vaktmester = Vaktmester(DataSource.instance)
+            vaktmester.rydd()
+            assertThrows<InntektNotFoundException> { inntektStore.getInntekt(ubruktEldreEnn90Dager.inntektId) }
+            inntektStore.getInntekt(ubruktYngreEnn90Dager.inntektId) shouldBe ubruktYngreEnn90Dager
+        }
+        CollectorRegistry.defaultRegistry.metricFamilySamples().asSequence().find { it.name == "inntekt_slettet" }
+            ?.let { metric ->
+                metric.samples[0].value shouldNotBe null
+                metric.samples[0].value shouldBeGreaterThan 0.0
+            } ?: AssertionError("Could not find metric")
+    }
+}

--- a/src/test/kotlin/no/nav/dagpenger/inntekt/v1/UklassifisertInntektApiTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/inntekt/v1/UklassifisertInntektApiTest.kt
@@ -87,14 +87,15 @@ class UklassifisertInntektApiTest {
         } returns inntektId
 
         every {
-            inntektStoreMock.insertInntekt(foundBehandlingsKey, storedInntekt.inntekt, null)
+            inntektStoreMock.insertInntekt(foundBehandlingsKey, storedInntekt.inntekt, null, any())
         } returns storedInntekt
 
         every {
             inntektStoreMock.insertInntekt(
                 foundBehandlingsKey,
                 storedInntekt.inntekt,
-                ManueltRedigert.from(true, "user")
+                ManueltRedigert.from(true, "user"),
+                any()
             )
         } returns storedInntekt
 


### PR DESCRIPTION
* Fjern ubrukte inntekter etter 3 måneder
- La til delete cascade opp mot arena mapping tabell
- La opprydding skje i gitte intervaller (12 timers intervaller)

(cherry picked from commit bdc7c9f47241872fa1e3c2bc7d1e68ef5255815f)

Prøver igjen - feil i stad var at testscenariene (flyway) har blitt kjørt i preprod/dev og de benyttet samme rekkefølge som ny migreringskript (`V2__INNTEKT_ARENA_MAPPING_DELETE_CASCADE.sql `. ). Renamet til `V1_6__INNTEKT_ARENA_MAPPING_DELETE_CASCADE.sql `