### PR TITLE
Remove CoroutineExceptionHandler from kafka consumer job

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -46,7 +46,7 @@ configurations.all {
 }
 
 dependencies {
-    implementation(kotlin("stdlib"))
+    implementation(kotlin("stdlib-jdk8"))
 
     implementation(Dagpenger.Events)
 


### PR DESCRIPTION
- Implementation of current CoroutineExceptionHandler will keep the coroutine "active", but the consumer will ble closed upon exception (use {} clause)